### PR TITLE
Update Friend Guard test with damage mocks

### DIFF
--- a/src/test/abilities/friend_guard.test.ts
+++ b/src/test/abilities/friend_guard.test.ts
@@ -6,6 +6,7 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { BattlerIndex } from "#app/battle";
 import { allAbilities } from "#app/data/ability";
+import { allMoves, MoveCategory } from "#app/data/move";
 
 describe("Moves - Friend Guard", () => {
   let phaserGame: Phaser.Game;
@@ -35,16 +36,20 @@ describe("Moves - Friend Guard", () => {
   it("should reduce damage that other allied Pokémon receive from attacks (from any Pokémon) by 25%", async () => {
     await game.classicMode.startBattle([ Species.BULBASAUR, Species.CHARMANDER ]);
     const [ player1, player2 ] = game.scene.getPlayerField();
-    const maxHP = player1.hp;
+    const spy = vi.spyOn(player1, "getAttackDamage");
+
+    const enemy1 = game.scene.getEnemyField()[0];
+
     game.move.select(Moves.SPLASH);
     game.move.select(Moves.SPLASH, 1);
     await game.forceEnemyMove(Moves.TACKLE, BattlerIndex.PLAYER);
     await game.forceEnemyMove(Moves.SPLASH);
     await game.toNextTurn();
-    const hp1 = player1.hp;
 
-    // Reset HP to maxHP
-    player1.hp = maxHP;
+    // Get the last return value from `getAttackDamage`
+    const turn1Damage = spy.mock.results[spy.mock.results.length - 1].value.damage;
+    // Making sure the test is controlled; turn 1 damage is equal to base damage (after rounding)
+    expect(turn1Damage).toBe(Math.floor(player1.getBaseDamage(enemy1, allMoves[Moves.TACKLE], MoveCategory.PHYSICAL)));
 
     vi.spyOn(player2, "getAbility").mockReturnValue(allAbilities[Abilities.FRIEND_GUARD]);
 
@@ -53,23 +58,26 @@ describe("Moves - Friend Guard", () => {
     await game.forceEnemyMove(Moves.TACKLE, BattlerIndex.PLAYER);
     await game.forceEnemyMove(Moves.SPLASH);
     await game.toNextTurn();
-    const hp2 = player1.hp;
-    expect(hp2).toBeGreaterThan(hp1);
+
+    // Get the last return value from `getAttackDamage`
+    const turn2Damage = spy.mock.results[spy.mock.results.length - 1].value.damage;
+    // With the ally's Friend Guard, damage should have been reduced from base damage by 25%
+    expect(turn2Damage).toBe(Math.floor(player1.getBaseDamage(enemy1, allMoves[Moves.TACKLE], MoveCategory.PHYSICAL) * 0.75));
   });
 
   it("should NOT reduce damage to pokemon with friend guard", async () => {
     await game.classicMode.startBattle([ Species.BULBASAUR, Species.CHARMANDER ]);
+
     const player2  = game.scene.getPlayerField()[1];
-    const maxHP = player2.hp;
+    const spy = vi.spyOn(player2, "getAttackDamage");
+
     game.move.select(Moves.SPLASH);
     game.move.select(Moves.SPLASH, 1);
     await game.forceEnemyMove(Moves.TACKLE, BattlerIndex.PLAYER_2);
     await game.forceEnemyMove(Moves.SPLASH);
     await game.toNextTurn();
-    const hp1 = player2.hp;
 
-    // Reset HP to maxHP
-    player2.hp = maxHP;
+    const turn1Damage = spy.mock.results[spy.mock.results.length - 1].value.damage;
 
     vi.spyOn(player2, "getAbility").mockReturnValue(allAbilities[Abilities.FRIEND_GUARD]);
 
@@ -78,23 +86,25 @@ describe("Moves - Friend Guard", () => {
     await game.forceEnemyMove(Moves.TACKLE, BattlerIndex.PLAYER_2);
     await game.forceEnemyMove(Moves.SPLASH);
     await game.toNextTurn();
-    const hp2 = player2.hp;
-    expect(hp2).toBe(hp1);
+
+    const turn2Damage = spy.mock.results[spy.mock.results.length - 1].value.damage;
+    expect(turn2Damage).toBe(turn1Damage);
   });
 
-  it("should NOT reduce damage from fixed damage attacks (i.e. dragon rage, sonic boom, etc)", async () => {
+  it("should NOT reduce damage from fixed damage attacks", async () => {
     await game.classicMode.startBattle([ Species.BULBASAUR, Species.CHARMANDER ]);
+
     const [ player1, player2 ] = game.scene.getPlayerField();
-    const maxHP = player1.hp;
+    const spy = vi.spyOn(player1, "getAttackDamage");
+
     game.move.select(Moves.SPLASH);
     game.move.select(Moves.SPLASH, 1);
     await game.forceEnemyMove(Moves.DRAGON_RAGE, BattlerIndex.PLAYER);
     await game.forceEnemyMove(Moves.SPLASH);
     await game.toNextTurn();
-    const hp1 = player1.hp;
 
-    // Reset HP to maxHP
-    player1.hp = maxHP;
+    const turn1Damage = spy.mock.results[spy.mock.results.length - 1].value.damage;
+    expect(turn1Damage).toBe(40);
 
     vi.spyOn(player2, "getAbility").mockReturnValue(allAbilities[Abilities.FRIEND_GUARD]);
 
@@ -103,7 +113,8 @@ describe("Moves - Friend Guard", () => {
     await game.forceEnemyMove(Moves.DRAGON_RAGE, BattlerIndex.PLAYER);
     await game.forceEnemyMove(Moves.SPLASH);
     await game.toNextTurn();
-    const hp2 = player1.hp;
-    expect(hp2).toBe(hp1);
+
+    const turn2Damage = spy.mock.results[spy.mock.results.length - 1].value.damage;
+    expect(turn2Damage).toBe(40);
   });
 });


### PR DESCRIPTION
I updated your tests for Friend Guard to spyon `getAttackDamage` for more accurate damage comparisons. The first test now checks that the damage reduction from Friend Guard is exactly 25%. This also means that the player's HP doesn't need to be reset between turns for the first 2 tests.
