### PR TITLE
Reuse Healing Wish's move attr, update test

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1881,8 +1881,14 @@ export class FlameBurstAttr extends MoveEffectAttr {
 }
 
 export class SacrificialFullRestoreAttr extends SacrificialAttr {
-  constructor() {
+  protected restorePP: boolean;
+  protected moveMessage: string;
+
+  constructor(restorePP: boolean, moveMessage: string) {
     super();
+
+    this.restorePP = restorePP;
+    this.moveMessage = moveMessage;
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -1893,36 +1899,19 @@ export class SacrificialFullRestoreAttr extends SacrificialAttr {
     // We don't know which party member will be chosen, so pick the highest max HP in the party
     const maxPartyMemberHp = user.scene.getPlayerParty().map(p => p.getMaxHp()).reduce((maxHp: integer, hp: integer) => Math.max(hp, maxHp), 0);
 
-    user.scene.pushPhase(new PokemonHealPhase(user.scene, user.getBattlerIndex(),
-      maxPartyMemberHp, i18next.t("moveTriggers:sacrificialFullRestore", { pokemonName: getPokemonNameWithAffix(user) }), true, false, false, true), true);
-
-    return true;
-  }
-
-  getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): integer {
-    return -20;
-  }
-
-  getCondition(): MoveConditionFunc {
-    return (user, _target, _move) => user.scene.getPlayerParty().filter(p => p.isActive()).length > user.scene.currentBattle.getBattlerCount();
-  }
-}
-
-export class SacrificialFullRestoreAndPPRestoreAttr extends SacrificialAttr {
-  constructor() {
-    super();
-  }
-
-  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    if (!super.apply(user, target, move, args)) {
-      return false;
-    }
-
-    // We don't know which party member will be chosen, so pick the highest max HP in the party
-    const maxPartyMemberHp = user.scene.getPlayerParty().map(p => p.getMaxHp()).reduce((maxHp: integer, hp: integer) => Math.max(hp, maxHp), 0);
-
-    user.scene.pushPhase(new PokemonHealPhase(user.scene, user.getBattlerIndex(),
-      maxPartyMemberHp, i18next.t("moveTriggers:lunarDanceRestore", { pokemonName: getPokemonNameWithAffix(user) }), false, false, false, true, false, true), true);
+    user.scene.pushPhase(
+      new PokemonHealPhase(
+        user.scene,
+        user.getBattlerIndex(),
+        maxPartyMemberHp,
+        i18next.t(this.moveMessage, { pokemonName: getPokemonNameWithAffix(user) }),
+        true,
+        false,
+        false,
+        true,
+        false,
+        this.restorePP),
+      true);
 
     return true;
   }
@@ -9030,7 +9019,7 @@ export function initMoves() {
       .attr(GyroBallPowerAttr)
       .ballBombMove(),
     new SelfStatusMove(Moves.HEALING_WISH, Type.PSYCHIC, -1, 10, -1, 0, 4)
-      .attr(SacrificialFullRestoreAttr)
+      .attr(SacrificialFullRestoreAttr, false, "moveTriggers:sacrificialFullRestore")
       .triageMove(),
     new AttackMove(Moves.BRINE, Type.WATER, MoveCategory.SPECIAL, 65, 100, 10, -1, 0, 4)
       .attr(MovePowerMultiplierAttr, (user, target, move) => target.getHpRatio() < 0.5 ? 2 : 1),
@@ -9307,7 +9296,7 @@ export function initMoves() {
     new AttackMove(Moves.SPACIAL_REND, Type.DRAGON, MoveCategory.SPECIAL, 100, 95, 5, -1, 0, 4)
       .attr(HighCritAttr),
     new SelfStatusMove(Moves.LUNAR_DANCE, Type.PSYCHIC, -1, 10, -1, 0, 4)
-      .attr(SacrificialFullRestoreAndPPRestoreAttr)
+      .attr(SacrificialFullRestoreAttr, true, "moveTriggers:lunarDanceRestore")
       .danceMove()
       .triageMove(),
     new AttackMove(Moves.CRUSH_GRIP, Type.NORMAL, MoveCategory.PHYSICAL, -1, 100, 5, -1, 0, 4)


### PR DESCRIPTION
Instead of creating a new nearly-identical move attr to Healing Wish's, I modified it to have a `restorePP` parameter that could be passed to the `PokemonHealPhase`.

Also I updated the test to use the new alternate moveset override (the existing override is unreliable when you need to check that properties of the pokemon's moveset have changed).